### PR TITLE
Fix: Default minute/second to 0 in alarm

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -151,9 +151,13 @@
         console.log(alarm);
 
         let date = new Date();
+
+        if(!alarm.m)alarm.m=0
+        if(!alarm.s)alarm.s=0
+
         date.setHours(alarm.h || 0);
-        date.setMinutes(alarm.m || 0);
-        date.setSeconds(alarm.s || 0);
+        date.setMinutes(alarm.m);
+        date.setSeconds(alarm.s);
 
         // if time set after, then do the future
         if (date.valueOf() < Date.now()) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -152,8 +152,8 @@
 
         let date = new Date();
 
-        if(!alarm.m)alarm.m=0
-        if(!alarm.s)alarm.s=0
+        if (!alarm.m) alarm.m = 0;
+        if (!alarm.s) alarm.s = 0;
 
         date.setHours(alarm.h || 0);
         date.setMinutes(alarm.m);


### PR DESCRIPTION
## Problem
Default minute/second to 0 in alarm

## Solution
Added if checks to check when minutes or seconds are left blank to be set to zero

closes #11  