### PR TITLE
fix: Automatically infer hour for alarm if left blank #9

### DIFF
--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -8,7 +8,7 @@
     import { PauseIcon, PlayIcon } from 'lucide-svelte';
     import { onDestroy } from 'svelte';
 
-    let { settings = $bindable() }: { settings: Settings } = $props();
+    let { settings = $bindable(), open = $bindable() }: { settings: Settings; open: boolean } = $props();
 
     let x = $state([settings.volume]);
     $effect(() => {
@@ -43,15 +43,21 @@
         }
     });
 
+    // Stop audio when dialog closes
+    $effect(() => {
+        if (!open && playing) {
+            audio.pause();
+            playing = false;
+        }
+    });
+
     const toggle_sound = () => {
         if (playing) {
             audio.pause();
             playing = false;
-            console.log('stopped audio');
         } else {
             audio.play();
             playing = true;
-            console.log('started audio', audio);
         }
     };
 

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -50,14 +50,16 @@
             playing = false;
         }
     });
-
+    
     const toggle_sound = () => {
         if (playing) {
             audio.pause();
             playing = false;
+            console.log('stopped audio');
         } else {
             audio.play();
             playing = true;
+            console.log('started audio', audio);
         }
     };
 

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -8,7 +8,8 @@
     import { PauseIcon, PlayIcon } from 'lucide-svelte';
     import { onDestroy } from 'svelte';
 
-    let { settings = $bindable(), open = $bindable() }: { settings: Settings; open: boolean } = $props();
+    let { settings = $bindable(), open = $bindable() }: { settings: Settings; open: boolean } =
+        $props();
 
     let x = $state([settings.volume]);
     $effect(() => {
@@ -50,7 +51,7 @@
             playing = false;
         }
     });
-    
+
     const toggle_sound = () => {
         if (playing) {
             audio.pause();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -292,6 +292,7 @@
                         type="number"
                         min="0"
                         oninput={update_input}
+                        disabled={!!active}
                         bind:value={countdown.h}
                     />
                     <span class="mx-1">:</span>
@@ -302,6 +303,7 @@
                         min="0"
                         max="59"
                         oninput={update_input}
+                        disabled={!!active}
                         bind:value={countdown.m}
                     />
                     <span class="mx-1">:</span>
@@ -312,6 +314,7 @@
                         min="0"
                         max="59"
                         oninput={update_input}
+                        disabled={!!active}
                         bind:value={countdown.s}
                     />
                 </div>
@@ -339,6 +342,7 @@
                         placeholder="h"
                         min="0"
                         oninput={update_input}
+                        disabled={!!active}
                         bind:value={alarm.h}
                     />
                     <span class="mx-1">:</span>
@@ -347,6 +351,7 @@
                         placeholder="m"
                         min="0"
                         max="59"
+                        disabled={!!active}
                         oninput={update_input}
                         bind:value={alarm.m}
                     />
@@ -357,6 +362,7 @@
                         min="0"
                         max="59"
                         oninput={update_input}
+                        disabled={!!active}
                         bind:value={alarm.s}
                     />
                 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -151,9 +151,10 @@
         console.log(alarm);
 
         let date = new Date();
-
+        
         if (!alarm.m) alarm.m = 0;
         if (!alarm.s) alarm.s = 0;
+        if (!alarm.h) alarm.h = date.getMinutes() > alarm.m ? date.getHours() + 1 : date.getHours()
 
         date.setHours(alarm.h || 0);
         date.setMinutes(alarm.m);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -151,9 +151,13 @@
         console.log(alarm);
 
         let date = new Date();
+
+        if(!alarm.m)alarm.m=0
+        if(!alarm.s)alarm.s=0
+
         date.setHours(alarm.h || 0);
-        date.setMinutes(alarm.m || 0);
-        date.setSeconds(alarm.s || 0);
+        date.setMinutes(alarm.m);
+        date.setSeconds(alarm.s);
 
         // if time set after, then do the future
         if (date.valueOf() < Date.now()) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -253,7 +253,7 @@
 </AlertDialog.Root>
 
 <Dialog.Root bind:open={settings_open}>
-    <SettingsDialog bind:settings />
+    <SettingsDialog bind:settings bind:open={settings_open} />
 </Dialog.Root>
 
 <div class="flex h-[100vh] flex-col justify-evenly">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -152,8 +152,8 @@
 
         let date = new Date();
 
-        if(!alarm.m)alarm.m=0
-        if(!alarm.s)alarm.s=0
+        if (!alarm.m) alarm.m = 0;
+        if (!alarm.s) alarm.s = 0;
 
         date.setHours(alarm.h || 0);
         date.setMinutes(alarm.m);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -153,7 +153,8 @@
 
         if (!alarm.m) alarm.m = 0;
         if (!alarm.s) alarm.s = 0;
-        if (!alarm.h) alarm.h = date.getMinutes() > alarm.m ? date.getHours() + 1 : date.getHours();
+        if (alarm.h === '')
+            alarm.h = date.getMinutes() > alarm.m ? date.getHours() + 1 : date.getHours();
 
         date.setHours(alarm.h);
         date.setMinutes(alarm.m);


### PR DESCRIPTION
## Problem
Automatically infer hour for alarm if left blank #9

Examples:

Specifying   :45:00 at 08:30 should set a timer that will go off at 08:45:00
Specifying   :15:00 at 08:30 should set a timer that will go off at 09:15:00

## Solution
Added if checks when hour was empty and check the current minutes we have now to know if we have to move to the next hour or the current hour we are having.

closes #9 